### PR TITLE
Use pointer for passing config to NewProgress

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -12,9 +12,7 @@ import (
 const loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
 
 func main() {
-	cfg := progress.GetDefaultOutputConfig()
-
-	taskLog := progress.NewProgress(cfg)
+	taskLog := progress.NewProgress(nil)
 	taskLog.Start()
 	defer taskLog.Stop()
 

--- a/progress.go
+++ b/progress.go
@@ -9,8 +9,10 @@ import (
 
 type OutputConfig messages.OutputConfig
 
-func GetDefaultOutputConfig() OutputConfig {
-	return OutputConfig(messages.GetDefaultOutputConfig())
+// GetDefaultOutputConfig returns pointer to a new instance of default output configuration.
+func GetDefaultOutputConfig() *OutputConfig {
+	config := OutputConfig(messages.GetDefaultOutputConfig())
+	return &config
 }
 
 type Progress struct {
@@ -22,11 +24,15 @@ type Progress struct {
 	doneChan   chan bool
 }
 
-// NewProgress creates new Progress instance.
-func NewProgress(config OutputConfig) *Progress {
+// NewProgress creates new Progress instance. Use nil config for default output configuration.
+func NewProgress(config *OutputConfig) *Progress {
+	if config == nil {
+		config = GetDefaultOutputConfig()
+	}
+
 	return &Progress{
 		store:     messages.NewMessageStore(),
-		renderer:  messages.NewMessageRenderer(messages.OutputConfig(config)),
+		renderer:  messages.NewMessageRenderer(messages.OutputConfig(*config)),
 		errorChan: make(chan error),
 		doneChan:  make(chan bool),
 	}

--- a/progress_test.go
+++ b/progress_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestProgress_Push_ErrorChannel(t *testing.T) {
 	t.Parallel()
-	taskLog := progress.NewProgress(progress.GetDefaultOutputConfig())
+	taskLog := progress.NewProgress(nil)
 	taskLog.Start()
 	defer taskLog.Stop()
 
@@ -27,7 +27,7 @@ func TestProgress_Push_ErrorChannel(t *testing.T) {
 
 func TestProgress_Start_PanicsIfCalledTwice(t *testing.T) {
 	t.Parallel()
-	taskLog := progress.NewProgress(progress.GetDefaultOutputConfig())
+	taskLog := progress.NewProgress(nil)
 	taskLog.Start()
 	defer taskLog.Stop()
 	assert.PanicsWithValue(t, "can not start progress log more than once", taskLog.Start)
@@ -35,14 +35,14 @@ func TestProgress_Start_PanicsIfCalledTwice(t *testing.T) {
 
 func TestProgress_Push_ErrorsIfCalledBeforeStart(t *testing.T) {
 	t.Parallel()
-	taskLog := progress.NewProgress(progress.GetDefaultOutputConfig())
+	taskLog := progress.NewProgress(nil)
 	err := taskLog.Push(messages.Update{})
 	assert.EqualError(t, err, "can not push updates into progress log that has not been started")
 }
 
 func TestProgress_Push_PanicsIfCalledAfterStop(t *testing.T) {
 	t.Parallel()
-	taskLog := progress.NewProgress(progress.GetDefaultOutputConfig())
+	taskLog := progress.NewProgress(nil)
 	taskLog.Start()
 	taskLog.Stop()
 	assert.Panics(t, func() { _ = taskLog.Push(messages.Update{}) })
@@ -50,13 +50,13 @@ func TestProgress_Push_PanicsIfCalledAfterStop(t *testing.T) {
 
 func TestProgress_Stop_PanicsIfCalledBeforeStart(t *testing.T) {
 	t.Parallel()
-	taskLog := progress.NewProgress(progress.GetDefaultOutputConfig())
+	taskLog := progress.NewProgress(nil)
 	assert.PanicsWithValue(t, "can not stop progress log that has not been started", taskLog.Stop)
 }
 
 func TestProgress_Stop_PanicsIfCalledTwice(t *testing.T) {
 	t.Parallel()
-	taskLog := progress.NewProgress(progress.GetDefaultOutputConfig())
+	taskLog := progress.NewProgress(nil)
 	taskLog.Start()
 	taskLog.Stop()
 	assert.Panics(t, taskLog.Stop)


### PR DESCRIPTION
This makes using default output configuration slightly easier.