### PR TITLE
fix: do not output `ProgressMessage` to non-interactive terminals

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -143,10 +143,6 @@ linters:
     # using `pkg/errors`, but those are generally moving towards stdlib.
     - errorlint
 
-    # Checks that SQL statements are executed with the appropriate `.Exec` or
-    # `.Query` function.
-    - execinquery
-
     # Checks that switches of enum(-like) types cover every possible case.
     # Very helpful when we need to add new cases to enums, making sure that all
     # the relevant bits are checked. Can become annoying if there's a _lot_ of
@@ -453,10 +449,6 @@ linters:
     # problems.
     - staticcheck
 
-    # Finds unused struct fields, i.e. fields that are not referenced from
-    # anywhere else. Helps remove dead code.
-    - structcheck
-
     # Encourages various opinionated styles and rules including naming.
     # Redundant with `revive`.
     ## - stylecheck # DISABLE
@@ -518,9 +510,6 @@ linters:
 
     # Endorse use of various consts and variables defined in stdlib.
     - usestdlibvars
-
-    # Finds unused global variables and constants. Helps remove dead code.
-    - varcheck
 
     # Variable name length checks, takes definition and use span lengths into
     # account. Nice idea, idiomatic Go, but needs discussion if we want to go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,28 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not output `ProgressMessage` to non-interactive terminals. This avoids including a progress update in the started message that is printed to non-interactive terminals.
+
 ## [v1.0.2] - 2022-11-23
 
 ### Fixed
+
 - Normalise whitespace (`\s` → ` `) in messages to avoid newlines and tabs breaking in-progress message updating.
 - Assume details message to be preformatted, if it contains newline characters (`\n`). Preformatted message details are wrapped so that newline characters are maintained. This makes, for example, stack traces and console output in message details more readable.
 
 ## [v1.0.1] - 2022-08-30
 
 ### Fixed
+
 - Do not try to render message if terminal width is zero. This happens with some terminals on first terminal width get(s).
 
 ## [v1.0.0] - 2022-08-26
 
 ### Added
-- Extract and refactor livelog functionality from [UpCloud CLI (`upctl`)](https://github.com/UpCloudLtd/upcloud-cli.git).
 
+- Extract and refactor livelog functionality from [UpCloud CLI (`upctl`)](https://github.com/UpCloudLtd/upcloud-cli.git).
 
 [Unreleased]: https://github.com/UpCloudLtd/progress/compare/v1.0.2...HEAD
 [v1.0.2]: https://github.com/UpCloudLtd/progress/compare/v1.0.1...v1.0.2

--- a/messages/output.go
+++ b/messages/output.go
@@ -190,11 +190,13 @@ func (cfg OutputConfig) formatDetails(msg *Message) string {
 }
 
 func (cfg OutputConfig) GetMessageText(msg *Message, renderState RenderState) string {
+	isInteractive := cfg.GetMaxHeight() > 0
+
 	status := ""
 	color := cfg.getStatusColor(msg.Status)
 	if cfg.ShowStatusIndicator {
 		indicator := cfg.getStatusIndicator(msg.Status)
-		if msg.Status.IsInProgress() && cfg.GetMaxHeight() > 0 {
+		if msg.Status.IsInProgress() && isInteractive {
 			indicator = cfg.getInProgressAnimationFrame(renderState)
 		}
 
@@ -208,7 +210,7 @@ func (cfg OutputConfig) GetMessageText(msg *Message, renderState RenderState) st
 
 	lenFn := text.RuneWidthWithoutEscSequences
 	message := msg.Message
-	if msg.ProgressMessage != "" {
+	if isInteractive && msg.ProgressMessage != "" {
 		message += " " + msg.ProgressMessage
 	}
 	maxMessageWidth := cfg.GetMaxWidth() - lenFn(status) - lenFn(elapsed)


### PR DESCRIPTION
This avoids including first progress update in the _started_ message that is printed to non-interactive terminals.

Before:

```
> Running examples/create_and_restore_backup.md (Step 3 of 10)                                      
[...]
✓ Running examples/create_and_restore_backup.md                                                360 s
```

After:

```
> Running examples/create_and_restore_backup.md                                      
[...]
✓ Running examples/create_and_restore_backup.md                                                360 s
```